### PR TITLE
♻️ [Fix/graph-score-124] 그래프 차트 API 분리 작업 

### DIFF
--- a/src/main/java/kr/co/antoon/common/dto/SwaggerNote.java
+++ b/src/main/java/kr/co/antoon/common/dto/SwaggerNote.java
@@ -327,7 +327,8 @@ public class SwaggerNote {
     public static final String WEBTOON_READ_RANKING_NOTE = """
             현재 시간 기준으로 상승 중인 웹툰 조회
             GET /api/v1/webtoons/top-up
-                        
+            
+            Response Body
             {
                "webtoons": [
                  {
@@ -340,41 +341,88 @@ public class SwaggerNote {
                    "snapshotTime": "2022-05-13T03:59:01",
                    "activeStatus": "연재",
                    "platform": "KAKAO"
-                 },
-                 {
-                   "id": 605,
-                   "url": "https://page.kakao.com/home?seriesId=58777646",
-                   "thumbnail": "https://dn-img-page.kakao.com/download/resource?kid=KWNVT/hzp2f362bW/NWT2ViqCrkIlWJhAlPwQp1&filename=th2",
-                   "title": "백작가의 사생아가 결혼하면",
-                   "score": 650,
-                   "scoreGapPercent": 0,
-                   "snapshotTime": "2022-05-13T03:59:01",
-                   "activeStatus": "연재",
-                   "platform": "KAKAO"
-                 },
-                 {
-                   "id": 617,
-                   "url": "https://page.kakao.com/home?seriesId=58663937",
-                   "thumbnail": "https://dn-img-page.kakao.com/download/resource?kid=c9BidG/hzhOhJV5W3/ApkqR0bIKHmF8faTtNCm60&filename=th2",
-                   "title": "남편님, 다시 결혼해 주세요!",
-                   "score": 650,
-                   "scoreGapPercent": 0,
-                   "snapshotTime": "2022-05-13T03:59:02",
-                   "activeStatus": "연재",
-                   "platform": "KAKAO"
-                 },
-                 {
-                   "id": 539,
-                   "url": "https://page.kakao.com/home?seriesId=56657309",
-                   "thumbnail": "https://dn-img-page.kakao.com/download/resource?kid=ceQX6q/hzmU2m9nxu/dJoslDiIylEt2nzmoSCCeK&filename=th2",
-                   "title": "당신의 이해를 돕기 위하여",
-                   "score": 650,
-                   "scoreGapPercent": 0,
-                   "snapshotTime": "2022-05-11T22:55:13",
-                   "activeStatus": "연재",
-                   "platform": "KAKAO"
                  }
                ]
              }
+            """;
+    public static final String GRAPH_SCORES_DAY_READ_NOTE = """
+            1일 기준 그래프 조회
+            GET /api/v1/webtoons/{webtoonId}/graph-scores/days
+            
+            Response Body            
+            {
+              "count": 32,
+              "graphScores": [
+                {
+                  "graphScore": 648,
+                  "scoreGap": 0,
+                  "scoreGapPercent": 0,
+                  "webtoonId": 1,
+                  "snapshotTime": "2022-05-28T14:00:45",
+                  "status": "MAINTAIN",
+                  "graphStatusDescription": "유지"
+                }
+              ]
+            }
+            """;
+    public static final String GRAPH_SCORES_WEEKENDS_READ_NOTE = """
+            1주일 기준 그래프 조회
+            GET /api/v1/webtoons/{webtoonId}/graph-scores/weekends
+            
+            Response Body
+            {
+              "count": 7,
+              "graphScores": [
+                {
+                  "graphScore": 648,
+                  "scoreGap": 0,
+                  "scoreGapPercent": 0,
+                  "webtoonId": 1,
+                  "snapshotTime": "2022-05-29T13:00:35",
+                  "status": "MAINTAIN",
+                  "graphStatusDescription": "유지"
+                }
+              ]
+            }
+            """;
+    public static final String GRAPH_SCORES_MONTHS_READ_NOTE = """
+            1달 기준 그래프 조회
+            GET /api/v1/webtoons/{webtoonId}/graph-scores/months
+            
+            ResponseBody
+            {
+              "count": 0,
+              "graphScores": [
+                {
+                  "graphScore": 0,
+                  "graphStatusDescription": "string",
+                  "scoreGap": 0,
+                  "scoreGapPercent": 0,
+                  "snapshotTime": "2022-05-29T04:27:36.088Z",
+                  "status": "DOWN",
+                  "webtoonId": 0
+                }
+              ]
+            }
+            """;
+    public static final String GRAPH_SCORE_THREE_MONTH_READ_NOTE = """
+            3개월 기준 그래프 조회
+            GET /api/v1/webtoons/{webtoonId}/graph-scores/three-months
+            
+            ResponseBody
+            {
+              "count": 0,
+              "graphScores": [
+                {
+                  "graphScore": 0,
+                  "graphStatusDescription": "string",
+                  "scoreGap": 0,
+                  "scoreGapPercent": 0,
+                  "snapshotTime": "2022-05-29T04:28:40.611Z",
+                  "status": "DOWN",
+                  "webtoonId": 0
+                }
+              ]
+            }
             """;
 }

--- a/src/main/java/kr/co/antoon/graph/application/GraphScoreSnapshotService.java
+++ b/src/main/java/kr/co/antoon/graph/application/GraphScoreSnapshotService.java
@@ -11,9 +11,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -66,48 +67,27 @@ public class GraphScoreSnapshotService {
 
     @Transactional(readOnly = true)
     public GraphScoreResponse graphByWeekends(Long webtoonId, Period period) {
-        var end = LocalDateTime.now();
-        var start = end.minusDays(period.getDays());
-
-        List<GraphScoreSnapshot> graphScoreSnapshots = new ArrayList<>();
-        for (LocalDateTime date = start; date.isBefore(end); date = date.plusDays(1)) {
-            GraphScoreSnapshot graphScoreSnapshot = graphScoreSnapshotRepository.findTop1ByWebtoonIdAndSnapshotTimeBetweenOrderByCreatedAtDesc(webtoonId, start, end);
-            graphScoreSnapshots.add(graphScoreSnapshot);
-        }
-
-        var score = graphScoreSnapshots.stream().map(GraphScoreResponse.GraphScoreDetail::new)
-                .toList();
-
-        return new GraphScoreResponse(score);
+        return getGraphScoreResponse(webtoonId, period);
     }
 
     @Transactional(readOnly = true)
     public GraphScoreResponse graphByMonths(Long webtoonId, Period period) {
-        var end = LocalDateTime.now();
-        var start = end.minusDays(period.getDays());
-
-        List<GraphScoreSnapshot> graphScoreSnapshots = new ArrayList<>();
-        for (LocalDateTime date = start; date.isBefore(end); date = date.plusDays(1)) {
-            GraphScoreSnapshot graphScoreSnapshot = graphScoreSnapshotRepository.findTop1ByWebtoonIdAndSnapshotTimeBetweenOrderByCreatedAtDesc(webtoonId, start, end);
-            graphScoreSnapshots.add(graphScoreSnapshot);
-        }
-
-        var score = graphScoreSnapshots.stream().map(GraphScoreResponse.GraphScoreDetail::new)
-                .toList();
-
-        return new GraphScoreResponse(score);
+        return getGraphScoreResponse(webtoonId, period);
     }
 
     @Transactional(readOnly = true)
     public GraphScoreResponse graphByThreeMonths(Long webtoonId, Period period) {
+        return getGraphScoreResponse(webtoonId, period);
+    }
+
+    private GraphScoreResponse getGraphScoreResponse(Long webtoonId, Period period) {
         var end = LocalDateTime.now();
         var start = end.minusDays(period.getDays());
 
-        List<GraphScoreSnapshot> graphScoreSnapshots = new ArrayList<>();
-        for (LocalDateTime date = start; date.isBefore(end); date = date.plusDays(1)) {
-            GraphScoreSnapshot graphScoreSnapshot = graphScoreSnapshotRepository.findTop1ByWebtoonIdAndSnapshotTimeBetweenOrderByCreatedAtDesc(webtoonId, start, end);
-            graphScoreSnapshots.add(graphScoreSnapshot);
-        }
+        var graphScoreSnapshots = Stream
+                .iterate(start, date -> date.isBefore(end), date -> date.plusDays(1))
+                .map(date -> graphScoreSnapshotRepository.findTop1ByWebtoonIdAndSnapshotTimeBetweenOrderByCreatedAtDesc(webtoonId, start, end))
+                .collect(Collectors.toList());
 
         var score = graphScoreSnapshots.stream().map(GraphScoreResponse.GraphScoreDetail::new)
                 .toList();

--- a/src/main/java/kr/co/antoon/graph/application/GraphScoreSnapshotService.java
+++ b/src/main/java/kr/co/antoon/graph/application/GraphScoreSnapshotService.java
@@ -66,30 +66,17 @@ public class GraphScoreSnapshotService {
     }
 
     @Transactional(readOnly = true)
-    public GraphScoreResponse graphByWeekends(Long webtoonId, Period period) {
-        return getGraphScoreResponse(webtoonId, period);
-    }
-
-    @Transactional(readOnly = true)
-    public GraphScoreResponse graphByMonths(Long webtoonId, Period period) {
-        return getGraphScoreResponse(webtoonId, period);
-    }
-
-    @Transactional(readOnly = true)
-    public GraphScoreResponse graphByThreeMonths(Long webtoonId, Period period) {
-        return getGraphScoreResponse(webtoonId, period);
-    }
-
-    private GraphScoreResponse getGraphScoreResponse(Long webtoonId, Period period) {
+    public GraphScoreResponse graphByMoreThanWeek(Long webtoonId, Period period) {
         var end = LocalDateTime.now();
         var start = end.minusDays(period.getDays());
 
         var graphScoreSnapshots = Stream
                 .iterate(start, date -> date.isBefore(end), date -> date.plusDays(1))
-                .map(date -> graphScoreSnapshotRepository.findTop1ByWebtoonIdAndSnapshotTimeBetweenOrderByCreatedAtDesc(webtoonId, start, end))
+                .map(date -> graphScoreSnapshotRepository.findTopOneByWebtoonIdAndSnapshotTimeBetweenOrderByCreatedAtDesc(webtoonId, start, end))
                 .collect(Collectors.toList());
 
-        var score = graphScoreSnapshots.stream().map(GraphScoreResponse.GraphScoreDetail::new)
+        var score = graphScoreSnapshots.stream()
+                .map(GraphScoreResponse.GraphScoreDetail::new)
                 .toList();
 
         return new GraphScoreResponse(score);

--- a/src/main/java/kr/co/antoon/graph/application/GraphScoreSnapshotService.java
+++ b/src/main/java/kr/co/antoon/graph/application/GraphScoreSnapshotService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -51,7 +52,7 @@ public class GraphScoreSnapshotService {
     }
 
     @Transactional(readOnly = true)
-    public GraphScoreResponse graph(Long webtoonId, Period period) {
+    public GraphScoreResponse graphByDays(Long webtoonId, Period period) {
         var end = LocalDateTime.now();
         var start = end.minusDays(period.getDays());
 
@@ -64,10 +65,63 @@ public class GraphScoreSnapshotService {
     }
 
     @Transactional(readOnly = true)
+    public GraphScoreResponse graphByWeekends(Long webtoonId, Period period) {
+        var end = LocalDateTime.now();
+        var start = end.minusDays(period.getDays());
+
+        List<GraphScoreSnapshot> graphScoreSnapshots = new ArrayList<>();
+        for (LocalDateTime date = start; date.isBefore(end); date = date.plusDays(1)) {
+            GraphScoreSnapshot graphScoreSnapshot = graphScoreSnapshotRepository.findTop1ByWebtoonIdAndSnapshotTimeBetweenOrderByCreatedAtDesc(webtoonId, start, end);
+            graphScoreSnapshots.add(graphScoreSnapshot);
+        }
+
+        var score = graphScoreSnapshots.stream().map(GraphScoreResponse.GraphScoreDetail::new)
+                .toList();
+
+        return new GraphScoreResponse(score);
+    }
+
+    @Transactional(readOnly = true)
+    public GraphScoreResponse graphByMonths(Long webtoonId, Period period) {
+        var end = LocalDateTime.now();
+        var start = end.minusDays(period.getDays());
+
+        List<GraphScoreSnapshot> graphScoreSnapshots = new ArrayList<>();
+        for (LocalDateTime date = start; date.isBefore(end); date = date.plusDays(1)) {
+            GraphScoreSnapshot graphScoreSnapshot = graphScoreSnapshotRepository.findTop1ByWebtoonIdAndSnapshotTimeBetweenOrderByCreatedAtDesc(webtoonId, start, end);
+            graphScoreSnapshots.add(graphScoreSnapshot);
+        }
+
+        var score = graphScoreSnapshots.stream().map(GraphScoreResponse.GraphScoreDetail::new)
+                .toList();
+
+        return new GraphScoreResponse(score);
+    }
+
+    @Transactional(readOnly = true)
+    public GraphScoreResponse graphByThreeMonths(Long webtoonId, Period period) {
+        var end = LocalDateTime.now();
+        var start = end.minusDays(period.getDays());
+
+        List<GraphScoreSnapshot> graphScoreSnapshots = new ArrayList<>();
+        for (LocalDateTime date = start; date.isBefore(end); date = date.plusDays(1)) {
+            GraphScoreSnapshot graphScoreSnapshot = graphScoreSnapshotRepository.findTop1ByWebtoonIdAndSnapshotTimeBetweenOrderByCreatedAtDesc(webtoonId, start, end);
+            graphScoreSnapshots.add(graphScoreSnapshot);
+        }
+
+        var score = graphScoreSnapshots.stream().map(GraphScoreResponse.GraphScoreDetail::new)
+                .toList();
+
+        return new GraphScoreResponse(score);
+    }
+
+    @Transactional(readOnly = true)
     public List<GraphScoreSnapshot> findTop10ByOrderByScoreGap() {
         var end = LocalDateTime.now();
         var start = end.minusHours(1);
 
         return graphScoreSnapshotRepository.findDistinctTop10BySnapshotTimeBetweenOrderByScoreGapDescGraphScoreDesc(start, end);
     }
+
+
 }

--- a/src/main/java/kr/co/antoon/graph/infrastructure/GraphScoreSnapshotRepository.java
+++ b/src/main/java/kr/co/antoon/graph/infrastructure/GraphScoreSnapshotRepository.java
@@ -19,4 +19,6 @@ public interface GraphScoreSnapshotRepository extends JpaRepository<GraphScoreSn
     Optional<GraphScoreSnapshot> findTop1ByWebtoonIdOrderBySnapshotTimeDesc(Long webtoondId);
 
     List<GraphScoreSnapshot> findAllByWebtoonIdAndSnapshotTimeBetweenOrderByCreatedAtAsc(Long webtoonId, LocalDateTime start, LocalDateTime end);
+
+    GraphScoreSnapshot findTop1ByWebtoonIdAndSnapshotTimeBetweenOrderByCreatedAtDesc(Long webtoonId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/kr/co/antoon/graph/infrastructure/GraphScoreSnapshotRepository.java
+++ b/src/main/java/kr/co/antoon/graph/infrastructure/GraphScoreSnapshotRepository.java
@@ -20,5 +20,5 @@ public interface GraphScoreSnapshotRepository extends JpaRepository<GraphScoreSn
 
     List<GraphScoreSnapshot> findAllByWebtoonIdAndSnapshotTimeBetweenOrderByCreatedAtAsc(Long webtoonId, LocalDateTime start, LocalDateTime end);
 
-    GraphScoreSnapshot findTop1ByWebtoonIdAndSnapshotTimeBetweenOrderByCreatedAtDesc(Long webtoonId, LocalDateTime start, LocalDateTime end);
+    GraphScoreSnapshot findTopOneByWebtoonIdAndSnapshotTimeBetweenOrderByCreatedAtDesc(Long webtoonId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/kr/co/antoon/graph/presentation/GraphScoreController.java
+++ b/src/main/java/kr/co/antoon/graph/presentation/GraphScoreController.java
@@ -10,7 +10,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import static kr.co.antoon.common.util.CommonUtil.APPLICATION_JSON_UTF_8;
@@ -22,12 +21,38 @@ import static kr.co.antoon.common.util.CommonUtil.APPLICATION_JSON_UTF_8;
 public class GraphScoreController {
     private final GraphScoreSnapshotService graphScoreSnapshotService;
 
-    @ApiOperation(value = "그래프 API", notes = "추후 작성 필요")
-    @GetMapping("/webtoons/{webtoonId}/graph-scores")
-    public ResponseEntity<GraphScoreResponse> get(
-            @PathVariable("webtoonId") Long webtoonId,
-            @RequestParam("period") String period
-    ) {
+    @ApiOperation(value = "일 단위 그래프 API", notes = "추후 작성 필요")
+    @GetMapping("/webtoons/{webtoonId}/graph-scores/days")
+    public ResponseEntity<GraphScoreResponse> getByDays(
+            @PathVariable("webtoonId") Long webtoonId) {
+        var period = "day";
+        var response = graphScoreSnapshotService.graph(webtoonId, Period.of(period));
+        return ResponseEntity.ok(response);
+    }
+
+    @ApiOperation(value = "주 단위 그래프 API", notes = "추후 작성 필요")
+    @GetMapping("/webtoons/{webtoonId}/graph-scores/weekends")
+    public ResponseEntity<GraphScoreResponse> getByWeekends(
+            @PathVariable("webtoonId") Long webtoonId) {
+        var period = "weekend";
+        var response = graphScoreSnapshotService.graph(webtoonId, Period.of(period));
+        return ResponseEntity.ok(response);
+    }
+
+    @ApiOperation(value = "월 단위 그래프 API", notes = "추후 작성 필요")
+    @GetMapping("/webtoons/{webtoonId}/graph-scores/months")
+    public ResponseEntity<GraphScoreResponse> getByMonths(
+            @PathVariable("webtoonId") Long webtoonId) {
+        var period = "month";
+        var response = graphScoreSnapshotService.graph(webtoonId, Period.of(period));
+        return ResponseEntity.ok(response);
+    }
+
+    @ApiOperation(value = "3개월 단위 그래프 API", notes = "추후 작성 필요")
+    @GetMapping("/webtoons/{webtoonId}/graph-scores/three-months")
+    public ResponseEntity<GraphScoreResponse> getByThreeMonths(
+            @PathVariable("webtoonId") Long webtoonId) {
+        var period = "three-month";
         var response = graphScoreSnapshotService.graph(webtoonId, Period.of(period));
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/kr/co/antoon/graph/presentation/GraphScoreController.java
+++ b/src/main/java/kr/co/antoon/graph/presentation/GraphScoreController.java
@@ -2,6 +2,7 @@ package kr.co.antoon.graph.presentation;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import kr.co.antoon.common.dto.SwaggerNote;
 import kr.co.antoon.graph.application.GraphScoreSnapshotService;
 import kr.co.antoon.graph.domain.vo.Period;
 import kr.co.antoon.graph.dto.response.GraphScoreResponse;
@@ -21,7 +22,7 @@ import static kr.co.antoon.common.util.CommonUtil.APPLICATION_JSON_UTF_8;
 public class GraphScoreController {
     private final GraphScoreSnapshotService graphScoreSnapshotService;
 
-    @ApiOperation(value = "일 단위 그래프 API", notes = "추후 작성 필요")
+    @ApiOperation(value = "일 단위 그래프 API", notes = SwaggerNote.GRAPH_SCORES_DAY_READ_NOTE)
     @GetMapping("/webtoons/{webtoonId}/graph-scores/days")
     public ResponseEntity<GraphScoreResponse> getByDays(
             @PathVariable("webtoonId") Long webtoonId) {
@@ -29,7 +30,7 @@ public class GraphScoreController {
         return ResponseEntity.ok(response);
     }
 
-    @ApiOperation(value = "주 단위 그래프 API", notes = "추후 작성 필요")
+    @ApiOperation(value = "주 단위 그래프 API", notes = SwaggerNote.GRAPH_SCORES_WEEKENDS_READ_NOTE)
     @GetMapping("/webtoons/{webtoonId}/graph-scores/weekends")
     public ResponseEntity<GraphScoreResponse> getByWeekends(
             @PathVariable("webtoonId") Long webtoonId) {
@@ -37,7 +38,7 @@ public class GraphScoreController {
         return ResponseEntity.ok(response);
     }
 
-    @ApiOperation(value = "월 단위 그래프 API", notes = "추후 작성 필요")
+    @ApiOperation(value = "월 단위 그래프 API", notes = SwaggerNote.GRAPH_SCORES_MONTHS_READ_NOTE)
     @GetMapping("/webtoons/{webtoonId}/graph-scores/months")
     public ResponseEntity<GraphScoreResponse> getByMonths(
             @PathVariable("webtoonId") Long webtoonId) {
@@ -45,7 +46,7 @@ public class GraphScoreController {
         return ResponseEntity.ok(response);
     }
 
-    @ApiOperation(value = "3개월 단위 그래프 API", notes = "추후 작성 필요")
+    @ApiOperation(value = "3개월 단위 그래프 API", notes = SwaggerNote.GRAPH_SCORE_THREE_MONTH_READ_NOTE)
     @GetMapping("/webtoons/{webtoonId}/graph-scores/three-months")
     public ResponseEntity<GraphScoreResponse> getByThreeMonths(
             @PathVariable("webtoonId") Long webtoonId) {

--- a/src/main/java/kr/co/antoon/graph/presentation/GraphScoreController.java
+++ b/src/main/java/kr/co/antoon/graph/presentation/GraphScoreController.java
@@ -33,7 +33,7 @@ public class GraphScoreController {
     @GetMapping("/webtoons/{webtoonId}/graph-scores/weekends")
     public ResponseEntity<GraphScoreResponse> getByWeekends(
             @PathVariable("webtoonId") Long webtoonId) {
-        var response = graphScoreSnapshotService.graphByWeekends(webtoonId, Period.of("weekend"));
+        var response = graphScoreSnapshotService.graphByMoreThanWeek(webtoonId, Period.of("weekend"));
         return ResponseEntity.ok(response);
     }
 
@@ -41,7 +41,7 @@ public class GraphScoreController {
     @GetMapping("/webtoons/{webtoonId}/graph-scores/months")
     public ResponseEntity<GraphScoreResponse> getByMonths(
             @PathVariable("webtoonId") Long webtoonId) {
-        var response = graphScoreSnapshotService.graphByMonths(webtoonId, Period.of("month"));
+        var response = graphScoreSnapshotService.graphByMoreThanWeek(webtoonId, Period.of("month"));
         return ResponseEntity.ok(response);
     }
 
@@ -49,7 +49,7 @@ public class GraphScoreController {
     @GetMapping("/webtoons/{webtoonId}/graph-scores/three-months")
     public ResponseEntity<GraphScoreResponse> getByThreeMonths(
             @PathVariable("webtoonId") Long webtoonId) {
-        var response = graphScoreSnapshotService.graphByThreeMonths(webtoonId, Period.of("three-month"));
+        var response = graphScoreSnapshotService.graphByMoreThanWeek(webtoonId, Period.of("three-month"));
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/kr/co/antoon/graph/presentation/GraphScoreController.java
+++ b/src/main/java/kr/co/antoon/graph/presentation/GraphScoreController.java
@@ -25,8 +25,7 @@ public class GraphScoreController {
     @GetMapping("/webtoons/{webtoonId}/graph-scores/days")
     public ResponseEntity<GraphScoreResponse> getByDays(
             @PathVariable("webtoonId") Long webtoonId) {
-        var period = "day";
-        var response = graphScoreSnapshotService.graph(webtoonId, Period.of(period));
+        var response = graphScoreSnapshotService.graphByDay(webtoonId, Period.of("day"));
         return ResponseEntity.ok(response);
     }
 
@@ -34,8 +33,7 @@ public class GraphScoreController {
     @GetMapping("/webtoons/{webtoonId}/graph-scores/weekends")
     public ResponseEntity<GraphScoreResponse> getByWeekends(
             @PathVariable("webtoonId") Long webtoonId) {
-        var period = "weekend";
-        var response = graphScoreSnapshotService.graph(webtoonId, Period.of(period));
+        var response = graphScoreSnapshotService.graphByWeekends(webtoonId, Period.of("weekend"));
         return ResponseEntity.ok(response);
     }
 
@@ -43,8 +41,7 @@ public class GraphScoreController {
     @GetMapping("/webtoons/{webtoonId}/graph-scores/months")
     public ResponseEntity<GraphScoreResponse> getByMonths(
             @PathVariable("webtoonId") Long webtoonId) {
-        var period = "month";
-        var response = graphScoreSnapshotService.graph(webtoonId, Period.of(period));
+        var response = graphScoreSnapshotService.graphByMonths(webtoonId, Period.of("month"));
         return ResponseEntity.ok(response);
     }
 
@@ -52,8 +49,7 @@ public class GraphScoreController {
     @GetMapping("/webtoons/{webtoonId}/graph-scores/three-months")
     public ResponseEntity<GraphScoreResponse> getByThreeMonths(
             @PathVariable("webtoonId") Long webtoonId) {
-        var period = "three-month";
-        var response = graphScoreSnapshotService.graph(webtoonId, Period.of(period));
+        var response = graphScoreSnapshotService.graphByThreeMonths(webtoonId, Period.of("three-month"));
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/kr/co/antoon/graph/presentation/GraphScoreController.java
+++ b/src/main/java/kr/co/antoon/graph/presentation/GraphScoreController.java
@@ -25,7 +25,7 @@ public class GraphScoreController {
     @GetMapping("/webtoons/{webtoonId}/graph-scores/days")
     public ResponseEntity<GraphScoreResponse> getByDays(
             @PathVariable("webtoonId") Long webtoonId) {
-        var response = graphScoreSnapshotService.graphByDay(webtoonId, Period.of("day"));
+        var response = graphScoreSnapshotService.graphByDays(webtoonId, Period.of("day"));
         return ResponseEntity.ok(response);
     }
 


### PR DESCRIPTION
### 💡 개요
- 그래프 차트 API 분리 작업 

<!-- #뒤에는 이슈 번호를 걸어주세요~ -->
- resolved #124

### 📑 작업 사항
- 그래프 차트 API를 일 단위 / 주 단위 / 월 단위 / 3개월 단위로 분리한다.
- 데이터가 너무 많아서 1주 이상부터는 종가 (scoreTime이 가장 최근인 값)을 뽑아서 반환값을 반환하도록 수정

### ✒️ 코드 리뷰 요청 사항
- 프론트엔드 분들의 연동 작업을 위해 선 PR 및 merge 후 코드 리팩토링을 진행할 예정입니다.


### ✔️ 코드 리뷰 반영 사항
- 저의 부족한 코드에 대한 코드 리뷰는 언제나 늘 감사합니다! ㅎㅎ
