### PR TITLE
:bug: [Fix/webtoon-detail-130] 웹툰 상세 조회 시 scoreGap, 랭킹, 탑승하차 상태 추가

### DIFF
--- a/src/main/java/kr/co/antoon/common/dto/SwaggerNote.java
+++ b/src/main/java/kr/co/antoon/common/dto/SwaggerNote.java
@@ -155,6 +155,7 @@ public class SwaggerNote {
                        "score": 650,
                        "scoreGap": 0,
                        "scoreGapPercent": 0,
+                       "recommendationStatus": "JOINED",
                        "ranking": 2
                      }
             """;

--- a/src/main/java/kr/co/antoon/webtoon/converter/WebtoonConverter.java
+++ b/src/main/java/kr/co/antoon/webtoon/converter/WebtoonConverter.java
@@ -53,6 +53,7 @@ public class WebtoonConverter {
                 webtoon.get(0).getGraphScore(),
                 webtoon.get(0).getScoreGap(),
                 getDifferencePercentage(webtoon.get(0).getGraphScore(), webtoon.get(0).getScoreGap()),
+                webtoon.get(0).getRecommendationStatus(),
                 webtoon.get(0).getRanking()
         );
     }

--- a/src/main/java/kr/co/antoon/webtoon/dto/WebtoonDto.java
+++ b/src/main/java/kr/co/antoon/webtoon/dto/WebtoonDto.java
@@ -1,6 +1,7 @@
 package kr.co.antoon.webtoon.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.antoon.recommendation.domain.vo.RecommendationStatus;
 import kr.co.antoon.webtoon.domain.vo.ActiveStatus;
 import kr.co.antoon.webtoon.domain.vo.GenreCategory;
 import kr.co.antoon.webtoon.domain.vo.Platform;
@@ -27,6 +28,7 @@ public record WebtoonDto(
         int score,
         int scoreGap,
         double scoreGapPercent,
+        RecommendationStatus recommendationStatus,
         Integer ranking
 ) {
     public record GenreDto(

--- a/src/main/java/kr/co/antoon/webtoon/dto/query/WebtoonNativeDto.java
+++ b/src/main/java/kr/co/antoon/webtoon/dto/query/WebtoonNativeDto.java
@@ -1,5 +1,6 @@
 package kr.co.antoon.webtoon.dto.query;
 
+import kr.co.antoon.recommendation.domain.vo.RecommendationStatus;
 import kr.co.antoon.webtoon.domain.vo.ActiveStatus;
 import kr.co.antoon.webtoon.domain.vo.GenreCategory;
 import kr.co.antoon.webtoon.domain.vo.Platform;
@@ -40,6 +41,8 @@ public interface WebtoonNativeDto {
     int getGraphScore();
 
     int getScoreGap();
+
+    RecommendationStatus getRecommendationStatus();
 
     Integer getRanking();
 }

--- a/src/main/java/kr/co/antoon/webtoon/infrastructure/WebtoonRepository.java
+++ b/src/main/java/kr/co/antoon/webtoon/infrastructure/WebtoonRepository.java
@@ -39,6 +39,7 @@ public interface WebtoonRepository extends JpaRepository<Webtoon, Long>, JpaSpec
             ww.id as webtoonWriterId, ww.name,
             rc.id as recommendationCountId, rc.join_count as joinCount, rc.leave_count as leaveCount,
             gss.graph_score as graphScore, gss.score_gap as scoreGap,
+            r.status as recommendationStatus,
             tr.ranking as ranking
             from webtoon w
             join webtoon_genre wg on w.id = wg.webtoon_id
@@ -46,6 +47,7 @@ public interface WebtoonRepository extends JpaRepository<Webtoon, Long>, JpaSpec
             join webtoon_writer ww on w.id = ww.webtoon_id
             join graph_score_snapshot gss on w.id = gss.webtoon_id
             left join recommendation_count rc on w.id = rc.webtoon_id
+            left join recommendation r on w.id = r.webtoon_id
             left join top_rank tr on w.id = tr.webtoon_id
             where w.id = :webtoon_id and gss.snapshot_time between :start_time and :end_time
             """, nativeQuery = true)


### PR DESCRIPTION
### 💡 개요
- 웹툰 상세 조회 시 response dto에 scoreGap, 랭킹, 탑승하차 상태 추가
- resolved #130 

### 📑 작업 사항
- 프론트엔드 요청으로 웹툰 상세 조회 시 response dto 변경 (scoreGap, 랭킹, 탑승하차 상태 추가)
- Swagger note 업데이트

### ✒️ 코드 리뷰 요청 사항


### ✔️ 코드 리뷰 반영 사항

